### PR TITLE
Fix bug with qml modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 This is early version of ownCloud music player wrote with Qt.<br><br>
 
+There is a way to achive Zen:<br>
+    - buy music (or rip own official CD via legal way)<br>
+    - setup your owncloud server<br>
+    - install music app for owncloud (see owncloud/music git repo)<br>
+    - add music collection to your own owncloud<br>
+    - build and install qwnPlayer to your device<br>
+    - login to owncloud from app<br>
+    - ???<br>
+    - profit<br><br>
+
 Tested on:<br>
     1) Win32 - everything is working<br>
     2) WinRT - playback isn't working - Qt bug (reported)<br>
@@ -11,12 +21,18 @@ Tested on:<br>
     5) OS X (10.11.3)- everything is working<br>
     6) SailfishOS (ARM, 2.0.0.10) - everything is working after installation of unofficial qt5-qtquickcontrols package<br>
         possible porting to qt5-qtquickcontrols-nemo by Mer/Nemo project<br>
-    7) Linux (Arch) - everything is working<br><br>
+    7) Linux (Arch) - everything is working<br>
+    8) Android (>= 5.*) - bug like on WinRT<br><br>
 
 Notes:<br>
     1) [Linux Users] Make sure, that you have qt5-graphicaleffects, qt5-qtquickcontrols<br><br>
 
 Known issues:<br>
-    1) Ugly UI<br>
+    1) Poor blayback implementation with QMultimedia. There are a lot of bugs and restrictions,<br>
+       particularly with playing password-protected url on new Android<br>
     2) QMultimedia use native playback backend - some formats on some platforms are unsupported<br>
-    3) Metadata is not showing correctly<br>
+    3) Metadata is not showing correctly<br><br>
+
+We have some bad thoughts about resolving some restrictions and bugs in QMultimedia by Qt team.<br>
+We wanna move the playback to libvlc from QMultimedia, i.e. using QtVLC.<br>
+So, we glad to see everyone of you, and we'll be pleasure, if you help us with qwnPlayer project!

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,17 +19,16 @@
 #include "QwnImageProvider.h"
 
 #ifdef SAILFISH_OS_HACK
-    #include <sailfishapp.h>
-    #define LoadGui SailfishApp::application(argc, argv)
+#include <sailfishapp.h>
+#define LoadGui SailfishApp::application(argc, argv)
 #else
-    #define LoadGui new QGuiApplication(argc, argv)
+#define LoadGui new QGuiApplication(argc, argv)
 #endif
 
 int main(int argc, char *argv[])
 {
-
 	// Run right application with params
-    QGuiApplication* app = LoadGui;
+	QGuiApplication* app = LoadGui;
 
 	// Debug message pattern
 	qSetMessagePattern("[%{time yyyyMMdd h:mm:ss.zzz}]\
@@ -62,6 +61,11 @@ int main(int argc, char *argv[])
 	// Create main qml component from engine and conext
 	QQmlComponent component(engine, QUrl("qrc:/qml/main.qml"));
 	QObject* topLevel = component.create(context);
+	if (!component.isReady()) {
+		qDebug() << component.errors();
+		app->quit();
+		return 0;
+	}
 
 	// Take window object from qml for further actions
 	QQuickWindow* window = qobject_cast<QQuickWindow*>(topLevel);


### PR DESCRIPTION
The application crashes if you haven't qt5-quickcontrols or
qt5-graphicaleffects modules which must be installed to your system with
Qt libraries.

There is the log of the application on crash:
// ===========================================================
[INFOWARNING]   [unknown:0 unknown] - QQmlComponent: Component is not
ready
[INFOWARNING]   [unknown:0 unknown] - QObject::connect: Cannot connect
(null)::signalCollectionData(QByteArray) to
ResponseDecoder::slotCollectionData(QByteArray)
Segmentation fault
// ===========================================================

I've found the only one way to check modules loading in runtime. If I
use isReady() function of QQmlComponent class after
component.create(context) function, I can use knowledge about errors in
engine to log it and to finish the app correctly.
So, now, developers know about the missing modules (check it in the
application log).

Other improvements:
- Update README.md file with info about using application, known issues,
  tested platforms and more.
